### PR TITLE
Remove cdap-etl-realtime

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
     <hydrator.version>1.6.0</hydrator.version>
     <widgets.dir>widgets</widgets.dir>
     <docs.dir>docs</docs.dir>
-    <app.parents>system:cdap-etl-batch[4.1.0,4.2.0-SNAPSHOT),system:cdap-etl-realtime[4.1.0,4.2.0-SNAPSHOT),system:cdap-data-pipeline[4.1.0,4.2.0-SNAPSHOT),system:cdap-data-streams[4.1.0,4.2.0-SNAPSHOT)</app.parents>
+    <app.parents>system:cdap-etl-batch[4.1.0,4.2.0-SNAPSHOT),system:cdap-data-pipeline[4.1.0,4.2.0-SNAPSHOT),system:cdap-data-streams[4.1.0,4.2.0-SNAPSHOT)</app.parents>
     <!-- this is here because project.basedir evaluates to null in the script build step -->
     <main.basedir>${project.basedir}</main.basedir>
   </properties>
@@ -304,7 +304,7 @@
               <Embed-Transitive>true</Embed-Transitive>
               <Embed-Directory>lib</Embed-Directory>
               <!--Only @Plugin classes in the export packages will be included as plugin-->
-              <_exportcontents>co.cask.wrangler.*</_exportcontents>
+              <_exportcontents>co.cask.hydrator.plugin.*</_exportcontents>
             </instructions>
           </configuration>
           <executions>


### PR DESCRIPTION
Remove `cdap-etl-realtime` parent
change export classes to `hydrator.plugin.*`

Verified cdap and hydrator versions
tested on cluster to see if the artifact appears on UI